### PR TITLE
Get 'resources' to display in META.*

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -36,7 +36,7 @@ my %WriteMakefileArgs = (
         "Test::Simple" => 0.44,
 		"utf8" => 0,
     },
-    ( eval { ExtUtils::MakeMaker->VERSION(6.46) } ? () : ( META_MERGE => {
+    ($mm_ver < 6.46 ? () : (META_MERGE => {
         'meta-spec' => { version => 2 },
         dynamic_config => 1,
         resources => {


### PR DESCRIPTION
An error in Makefile.PL was causing the 'resources' element not to be displayed in the META.json and META.yml files generated by 'make dist'. As a (likely) consequence, the rt.cpan.org page for XML-Easy was not displaying a "see the preferred bugtracker" banner.

Remove commented-out code