### PR TITLE
Fixes #13: undefined symbol: uvuni_to_utf8_flags

### DIFF
--- a/lib/XML/Easy.xs
+++ b/lib/XML/Easy.xs
@@ -44,6 +44,10 @@ static SV *empty_contentobject;
 	(!sv_is_glob(sv) && !sv_is_regexp(sv) && \
 	 (SvFLAGS(sv) & (SVf_IOK|SVf_NOK|SVf_POK|SVp_IOK|SVp_NOK|SVp_POK)))
 
+#ifndef uvchr_to_utf8_flags
+#define uvchr_to_utf8_flags(d, uv, flags) uvuni_to_utf8_flags(d, uv, flags);
+#endif
+
 /* exceptions */
 
 #define throw_utf8_error() croak("broken internal UTF-8 encoding\n")
@@ -1145,7 +1149,7 @@ static U8 *THX_parse_chars(pTHX_ U8 *p, SV *value, U8 endc, U32 flags)
 				vlen = SvCUR(value);
 				vstart = (U8*)SvGROW(value, vlen+4+1);
 				voldend = vstart + vlen;
-				vnewend = uvuni_to_utf8_flags(voldend, val,
+				vnewend = uvchr_to_utf8_flags(voldend, val,
 						UNICODE_ALLOW_ANY);
 				*vnewend = 0;
 				SvCUR_set(value, vnewend - vstart);


### PR DESCRIPTION
Patch-Source: https://sources.debian.org/data/main/libx/libxml-easy-perl/0.011-4/debian/patches/uvuni_to_utf8_flags.patch --
Description: Use uvchr_to_utf8_flags instead of uvuni_to_utf8_flags (removed in perl 5.38.0)
 Inspired by https://bugzilla.redhat.com/show_bug.cgi?id=2241708 and
 https://rt.cpan.org/Public/Bug/Display.html?id=149108
Origin: vendor
Bug-Debian: https://bugs.debian.org/1065785
Forwarded: not-yet, CPAN RT is not cooperative
Author: gregor herrmann <gregoa@debian.org>
Reviewed-by: gregor herrmann <gregoa@debian.org>
Last-Update: 2024-03-10